### PR TITLE
feat: usability tweaks to i3status rs bar.  remove non-localized data.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -6,16 +6,19 @@ icons = "awesome4"
 
 [[block]]
 block = "net"
+format = " $icon ^icon_net_down$speed_down.eng(prefix:K) ^icon_net_up$speed_up.eng(prefix:K) "
+format_alt = " $icon ^icon_net_down$graph_down ^icon_net_up$graph_up "
 
 [[block]]
 block = "disk_space"
 path = "/"
-info_type = "available"
+info_type = "free"
 alert_unit = "GB"
 interval = 20
-warning = 20.0
+warning = 15.0
 alert = 10.0
-format = " $icon $available.eng(w:2) "
+format = " $icon $free.eng(w:2) "
+format_alt = " $icon $available.eng(w:2) "
 
 [[block]]
 block = "memory"
@@ -24,7 +27,7 @@ format_alt = " $icon_swap $swap_used_percents.eng(w:2) "
 
 [[block]]
 block = "battery"
-format = " $icon\u2009 $percentage "
+format = " $icon\u00A0 $percentage "
 missing_format = ""
 device = "DisplayDevice"
 driver = "upower"
@@ -48,10 +51,4 @@ cmd = "regolith-control-center sound"
 [[block]]
 block = "time"
 interval = 5
-format = "\uf073 $timestamp.datetime(f:'%a-%d/%m/%y')"
-
-[[block]]
-block = "time"
-interval = 5
 format = "$icon $timestamp.datetime(f:'%R')"
-


### PR DESCRIPTION
* Change the disk space block to alert on low free percentage. As-is, was alerting on my bar although my disk is 85% free.  Add alt to show used space, default free 
* Remove date from block until there is a way to source from locale format (the default looks bad for those used to MM/DD format)
* Add alt to network w/ graph
* Tweak spacing of battery block icon/text due to quirky nerdfonts glyph width

